### PR TITLE
DTO-132 Feat: Daily 삭제 API 구현

### DIFF
--- a/src/main/java/com/dto/way/post/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/dto/way/post/aws/s3/AmazonS3Manager.java
@@ -1,5 +1,6 @@
 package com.dto.way.post.aws.s3;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -31,6 +32,16 @@ public class AmazonS3Manager{
         }
 
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public void deleteFile(String fileUrl) throws IOException{
+        int indexOfReviews = fileUrl.indexOf("daily_image/");
+        String fileKey = fileUrl.substring(indexOfReviews);
+        try{
+            amazonS3.deleteObject(amazonConfig.getBucket(),fileKey);
+        }catch (SdkClientException e) {
+            throw new IOException("Error deleting file from S3", e);
+        }
     }
 
     public String generateReviewKeyName(Uuid uuid) {

--- a/src/main/java/com/dto/way/post/converter/DailyConverter.java
+++ b/src/main/java/com/dto/way/post/converter/DailyConverter.java
@@ -33,4 +33,12 @@ public class DailyConverter {
                 .build();
     }
 
+    public static DailyResponseDto.DeleteDailyResultDto toDeleteDailyResponseDto(Daily daily) {
+        return DailyResponseDto.DeleteDailyResultDto.builder()
+                .id(daily.getId())
+                .title(daily.getTitle())
+                .deletedAt(LocalDateTime.now())
+                .build();
+    }
+
 }

--- a/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
@@ -23,7 +23,8 @@ public enum SuccessStatus implements BaseCode {
 
     //  게시글 관련 응답
     DAILY_CREATED(HttpStatus.OK, "DAILY2001", "Daily 게시글이 생성되었습니다."),
-    DAILY_UPDATED(HttpStatus.OK,"DAILY2002","Daily 게시글이 수정되었습니다.")
+    DAILY_UPDATED(HttpStatus.OK,"DAILY2002","Daily 게시글이 수정되었습니다."),
+    DAILY_DELETED(HttpStatus.OK,"DAILY2003","Daily 게시글이 삭제되었습니다.")
     ;
 
 

--- a/src/main/java/com/dto/way/post/service/DailyCommandService.java
+++ b/src/main/java/com/dto/way/post/service/DailyCommandService.java
@@ -2,10 +2,15 @@ package com.dto.way.post.service;
 
 import com.dto.way.post.domain.Daily;
 import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
+import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 public interface DailyCommandService {
     Daily createDaily(MultipartFile image, DailyRequestDto.CreateDailyDto requestDto);   //  회원 서비스 구현 완료시 수정사항 있음
 
     Daily updateDaily(Long dailyId, DailyRequestDto.UpdateDailyDto requestDto);
+
+    DailyResponseDto.DeleteDailyResultDto deleteDaily(Long dailyId) throws IOException;
 }

--- a/src/main/java/com/dto/way/post/service/DailyCommandServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/DailyCommandServiceImpl.java
@@ -7,11 +7,13 @@ import com.dto.way.post.domain.common.Uuid;
 import com.dto.way.post.repository.DailyRepository;
 import com.dto.way.post.repository.UuidRepository;
 import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
+import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -65,5 +67,17 @@ public class DailyCommandServiceImpl implements DailyCommandService {
         }
 
         return daily;
+    }
+
+    @Override
+    public DailyResponseDto.DeleteDailyResultDto deleteDaily(Long dailyId) throws IOException {
+
+        Daily daily = dailyRepository.findById(dailyId).orElseThrow(() -> new IllegalArgumentException("데일리가 존재하지 않습니다."));
+        s3Manager.deleteFile(daily.getImageUrl());
+        DailyResponseDto.DeleteDailyResultDto deleteDailyResultDto = DailyConverter.toDeleteDailyResponseDto(daily);
+
+        dailyRepository.delete(daily);
+
+        return deleteDailyResultDto;
     }
 }

--- a/src/main/java/com/dto/way/post/web/controller/DailyRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/DailyRestController.java
@@ -4,7 +4,6 @@ import com.dto.way.post.converter.DailyConverter;
 import com.dto.way.post.domain.Daily;
 import com.dto.way.post.global.response.ApiResponse;
 import com.dto.way.post.global.response.code.status.SuccessStatus;
-import com.dto.way.post.repository.DailyRepository;
 import com.dto.way.post.service.DailyCommandService;
 import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
 import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
@@ -12,16 +11,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+
 @RestController
 @RequestMapping("/post-service")
 @RequiredArgsConstructor
-public class DailyController {
+public class DailyRestController {
 
     private final DailyCommandService dailyCommandService;
 
     @PostMapping
-    public ApiResponse<DailyResponseDto.CreateDailyResultDto> createDaily(@RequestPart(value="image",required = true) MultipartFile image,
-                                                                          @RequestPart(value="createDailyDto") DailyRequestDto.CreateDailyDto request) {
+    public ApiResponse<DailyResponseDto.CreateDailyResultDto> createDaily(@RequestPart(value = "image", required = true) MultipartFile image,
+                                                                          @RequestPart(value = "createDailyDto") DailyRequestDto.CreateDailyDto request) {
         Daily daily = dailyCommandService.createDaily(image, request);
         return ApiResponse.of(SuccessStatus.DAILY_CREATED, DailyConverter.toCreateDailyResultDto(daily));
     }
@@ -32,5 +33,10 @@ public class DailyController {
 
         Daily daily = dailyCommandService.updateDaily(dailyId, request);
         return ApiResponse.of(SuccessStatus.DAILY_UPDATED, DailyConverter.toUpdateDailyResponseDto(daily));
+    }
+
+    @DeleteMapping("/{dailyId}")
+    public ApiResponse<DailyResponseDto.DeleteDailyResultDto> deleteDaily(@PathVariable(name = "dailyId") Long dailyId) throws IOException {
+        return ApiResponse.of(SuccessStatus.DAILY_DELETED, dailyCommandService.deleteDaily(dailyId));
     }
 }

--- a/src/main/java/com/dto/way/post/web/dto/dailyDto/DailyResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/dailyDto/DailyResponseDto.java
@@ -25,4 +25,14 @@ public class DailyResponseDto {
         private String title;
         private LocalDateTime updatedAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteDailyResultDto {
+        private Long id;
+        private String title;
+        private LocalDateTime deletedAt;
+    }
 }


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
Daily 삭제 API 구현 완료

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
path variable로 게시글 id 넘겨주면 해당 게시글을 데이터베이스에서 삭제하도록 구현함.
S3 버킷에 저장된 해당 게시글의 이미지도 함께 지워지도록 구현했음.
member service 구현 완료시 유효성 검사 로직 추가해야함. 

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
