### PR TITLE
DTO-259 Fix: S3 Manager 수정

### DIFF
--- a/src/main/java/com/dto/way/post/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/dto/way/post/aws/s3/AmazonS3Manager.java
@@ -4,7 +4,6 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.dto.way.post.domain.common.Uuid;
 import com.dto.way.post.global.config.AmazonConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,36 +15,33 @@ import java.io.IOException;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class AmazonS3Manager{
+public class AmazonS3Manager {
 
     private final AmazonS3 amazonS3;
-
     private final AmazonConfig amazonConfig;
 
-    public String uploadFile(String keyName, MultipartFile file){
+    public String uploadFileToDirectory(String directoryPath, String keyName, MultipartFile file) {
+        String fullKeyName = directoryPath + "/" + keyName;
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(file.getSize());
         try {
-            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
-        }catch (IOException e){
-            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), fullKeyName, file.getInputStream(), metadata));
+        } catch (IOException e) {
+            log.error("Error at AmazonS3Manager uploadFileToDirectory: {}", (Object) e.getStackTrace());
         }
-
-        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+        return amazonS3.getUrl(amazonConfig.getBucket(), fullKeyName).toString();
     }
 
-    public void deleteFile(String fileUrl) throws IOException{
-        int indexOfReviews = fileUrl.indexOf("daily_image/");
+
+    public void deleteFile(String directoryPath, String fileUrl) throws IOException {
+        int indexOfReviews = fileUrl.indexOf(directoryPath + "/");
+
         String fileKey = fileUrl.substring(indexOfReviews);
-        try{
-            amazonS3.deleteObject(amazonConfig.getBucket(),fileKey);
-        }catch (SdkClientException e) {
+        try {
+            amazonS3.deleteObject(amazonConfig.getBucket(), fileKey);
+        } catch (SdkClientException e) {
             throw new IOException("Error deleting file from S3", e);
         }
-    }
-
-    public String generateReviewKeyName(Uuid uuid) {
-        return amazonConfig.getDailyImagePath() + '/' + uuid.getUuid();
     }
 
 }

--- a/src/main/java/com/dto/way/post/global/config/AmazonConfig.java
+++ b/src/main/java/com/dto/way/post/global/config/AmazonConfig.java
@@ -31,8 +31,14 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Value("${cloud.aws.s3.path.daily}")
+    @Value("${cloud.aws.s3.path.daily_image}")
     private String dailyImagePath;
+
+    @Value("${cloud.aws.s3.path.history_body}")
+    private String historyBodyPath;
+
+    @Value("${cloud.aws.s3.path.history_thumbnail}")
+    private String historyThumbnailPath;
 
     @PostConstruct
     public void init() {

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyCommandServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.dto.way.post.converter.DailyConverter;
 import com.dto.way.post.domain.Daily;
 import com.dto.way.post.domain.Post;
 import com.dto.way.post.domain.common.Uuid;
+import com.dto.way.post.global.config.AmazonConfig;
 import com.dto.way.post.repository.DailyRepository;
 import com.dto.way.post.repository.UuidRepository;
 import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
@@ -29,6 +30,7 @@ public class DailyCommandServiceImpl implements DailyCommandService {
     private final DailyRepository dailyRepository;
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
+    private final AmazonConfig amazonConfig;
 
     @Override
     @Transactional
@@ -42,7 +44,7 @@ public class DailyCommandServiceImpl implements DailyCommandService {
                 .uuid(uuid)
                 .build());
 
-        String imageUrl = s3Manager.uploadFile(s3Manager.generateReviewKeyName(savedUuid), image);
+        String imageUrl = s3Manager.uploadFileToDirectory(amazonConfig.getDailyImagePath(), savedUuid.getUuid(), image);
 
 
         // 위도, 경도를 Point로 변환하여 저장.
@@ -85,7 +87,7 @@ public class DailyCommandServiceImpl implements DailyCommandService {
     public DailyResponseDto.DeleteDailyResultDto deleteDaily(Long postId) throws IOException {
 
         Daily daily = dailyRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("데일리가 존재하지 않습니다."));
-        s3Manager.deleteFile(daily.getImageUrl());
+        s3Manager.deleteFile(amazonConfig.getDailyImagePath(), daily.getImageUrl());
         DailyResponseDto.DeleteDailyResultDto deleteDailyResultDto = DailyConverter.toDeleteDailyResponseDto(daily);
 
         dailyRepository.delete(daily);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,9 @@ cloud:
     s3:
       bucket: way-post-images
       path:
-        daily: daily_image
+        daily_image: daily_image
+        history_body: history_body
+        history_thumbnail: history_thumbnail
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
S3 Manager 수정

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
- 기존의 데일리 이미지를 S3버킷에 저장하기 위해 구현한 S3 manager 수정, 이에 따라 DailyCommandServiceImpl에 약간의 수정 발생
- AmazonConfig에 저장할 디렉토리명을 명시하고, S3Manager의 업로드/삭제 메서드 호출 시 매개변수로 넘겨준다. 
- 기존의 S3Manager는 저장 및 삭제할 디렉토리를 daily_image로 넣어놔서 유연함이 떨어졌다. 이것을 메서드 호출 시 매개변수로 넘겨주게 함으로써 확장성 확보..



## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
