### PR TITLE
DTO-254 Feat: History 삭제 API 구현

### DIFF
--- a/src/main/java/com/dto/way/post/converter/HistoryConverter.java
+++ b/src/main/java/com/dto/way/post/converter/HistoryConverter.java
@@ -26,11 +26,19 @@ public class HistoryConverter {
                 .build();
     }
 
-    public static HistoryResponseDto.CreateHistoryResponseDto toCreateHistoryResponseDto(History history) {
-        return HistoryResponseDto.CreateHistoryResponseDto.builder()
+    public static HistoryResponseDto.CreateHistoryResultDto toCreateHistoryResponseDto(History history) {
+        return HistoryResponseDto.CreateHistoryResultDto.builder()
                 .postId(history.getPostId())
                 .title(history.getTitle())
                 .createAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static HistoryResponseDto.DeleteHistoryResultDto toDeleteHistoryResultDto(History history) {
+        return HistoryResponseDto.DeleteHistoryResultDto.builder()
+                .postId(history.getPostId())
+                .title(history.getTitle())
+                .deletedAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
@@ -34,7 +34,8 @@ public enum SuccessStatus implements BaseCode {
     DAILY_LIST_FOUND_BY_RANGE(HttpStatus.OK,"DAILY2005","반경 내 Daily 게시글 목록이 조회되었습니다."),
 
     //  히스토리 관련 응답
-    HISTORY_CREATED(HttpStatus.OK, "HISTORY2001", "History 게시글이 생성되었습니다. "),
+    HISTORY_CREATED(HttpStatus.OK, "HISTORY2001", "History 게시글이 생성되었습니다."),
+    HISTORY_DELETED(HttpStatus.OK, "HISTORY2002", "History 게시글이 삭제되었습니다."),
 
 
 

--- a/src/main/java/com/dto/way/post/repository/HistoryRepository.java
+++ b/src/main/java/com/dto/way/post/repository/HistoryRepository.java
@@ -3,6 +3,9 @@ package com.dto.way.post.repository;
 import com.dto.way.post.domain.History;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface HistoryRepository extends JpaRepository<History, Long> {
 
+    Optional<History> findById(Long Id);
 }

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryCommandService.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryCommandService.java
@@ -2,12 +2,16 @@ package com.dto.way.post.service.historyService;
 
 import com.dto.way.post.domain.History;
 import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
+import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
 import org.locationtech.jts.io.ParseException;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 public interface HistoryCommandService {
 
     History createHistory(MultipartFile thumbnailImage, MultipartFile bodyHtml, HistoryRequestDto.CreateHistoryDto createHistoryDto) throws ParseException;
 
+    HistoryResponseDto.DeleteHistoryResultDto deleteHistory(Long postId) throws IOException;
 
 }

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryCommandServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryCommandServiceImpl.java
@@ -8,12 +8,15 @@ import com.dto.way.post.aws.config.AmazonConfig;
 import com.dto.way.post.repository.HistoryRepository;
 import com.dto.way.post.utils.UuidCreator;
 import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
+import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -43,5 +46,18 @@ public class HistoryCommandServiceImpl implements HistoryCommandService {
         post.setMemberId(1L);
 
         return historyRepository.save(history);
+    }
+
+    @Override
+    public HistoryResponseDto.DeleteHistoryResultDto deleteHistory(Long postId) throws IOException {
+
+        History history = historyRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("히스토리가 존재하지 않습니다."));
+        s3Manager.deleteFile(amazonConfig.getHistoryThumbnailPath(), history.getThumbnailImageUrl());
+        s3Manager.deleteFile(amazonConfig.getHistoryBodyPath(), history.getBodyHtmlUrl());
+        HistoryResponseDto.DeleteHistoryResultDto deleteHistoryResultDto = HistoryConverter.toDeleteHistoryResultDto(history);
+
+        historyRepository.delete(history);
+
+        return deleteHistoryResultDto;
     }
 }

--- a/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
@@ -9,11 +9,10 @@ import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
 import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.io.ParseException;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 
 @RestController
@@ -23,10 +22,15 @@ public class HistoryRestController {
     private final HistoryCommandService historyCommandService;
 
     @PostMapping
-    public ApiResponse<HistoryResponseDto.CreateHistoryResponseDto> createHistory(@RequestPart(value = "image",required = true) MultipartFile thumbnailImage,
-                                                                                  @RequestPart(value = "html",required = true) MultipartFile bodyHtml,
-                                                                                  @RequestPart(value = "createHistoryDto", required = true)HistoryRequestDto.CreateHistoryDto request) throws ParseException {
+    public ApiResponse<HistoryResponseDto.CreateHistoryResultDto> createHistory(@RequestPart(value = "image",required = true) MultipartFile thumbnailImage,
+                                                                                @RequestPart(value = "html",required = true) MultipartFile bodyHtml,
+                                                                                @RequestPart(value = "createHistoryDto", required = true)HistoryRequestDto.CreateHistoryDto request) throws ParseException {
         History history = historyCommandService.createHistory(thumbnailImage, bodyHtml, request);
         return ApiResponse.of(SuccessStatus.HISTORY_CREATED, HistoryConverter.toCreateHistoryResponseDto(history));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ApiResponse<HistoryResponseDto.DeleteHistoryResultDto> deleteHistory(@PathVariable(name = "postId") Long postId) throws IOException {
+        return ApiResponse.of(SuccessStatus.HISTORY_DELETED, historyCommandService.deleteHistory(postId));
     }
 }

--- a/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
@@ -9,13 +9,24 @@ import java.time.LocalDateTime;
 
 public class HistoryResponseDto {
 
+
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class CreateHistoryResponseDto {
+    public static class CreateHistoryResultDto {
         private Long postId;
         private String title;
         private LocalDateTime createAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteHistoryResultDto {
+        private Long postId;
+        private String title;
+        private LocalDateTime deletedAt;
     }
 }


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
Feat: History 삭제 API 구현

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
API 호출 시 데이터베이스에서 History 및 Post 데이터가 삭제된다. 
S3에 저장된 해당 history의 썸네일 이미지 및 html파일도 삭제된다. 

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
