### PR TITLE
DTO-260 Fix: 게시글 반경 검색 api를 수정한다

### DIFF
--- a/src/main/java/com/dto/way/post/converter/PostConverter.java
+++ b/src/main/java/com/dto/way/post/converter/PostConverter.java
@@ -1,6 +1,7 @@
 package com.dto.way.post.converter;
 
 import com.dto.way.post.domain.Post;
+import com.dto.way.post.domain.enums.PostType;
 import com.dto.way.post.web.dto.postDto.PostResponseDto;
 
 import java.util.List;
@@ -9,16 +10,26 @@ import java.util.stream.Collectors;
 public class PostConverter {
 
     public static PostResponseDto.GetPostResultDto toGetPostResultDto(Post post) {
-        return PostResponseDto.GetPostResultDto.builder()
-                .postId(post.getId())
-                .memberId(post.getMemberId())
-                .title(post.getDaily().getTitle())
-                .body(post.getDaily().getBody())
-                .imageUrl(post.getDaily().getImageUrl())
-                .longitude(post.getLongitude())
-                .latitude(post.getLatitude())
-                .postType(post.getPostType())
-                .expiredAt(post.getDaily().getExpiredAt()).build();
+        if(post.getPostType()== PostType.DAILY){
+            return PostResponseDto.GetPostResultDto.builder()
+                    .postId(post.getId())
+                    .memberId(post.getMemberId())
+                    .title(post.getDaily().getTitle())
+                    .imageUrl(post.getDaily().getImageUrl())
+                    .postType(post.getPostType())
+                    .likesCount((long) post.getLikes().size())
+                    .build();
+        }else {
+            return PostResponseDto.GetPostResultDto.builder()
+                    .postId(post.getId())
+                    .memberId(post.getMemberId())
+                    .title(post.getHistory().getTitle())
+                    .imageUrl(post.getHistory().getThumbnailImageUrl())
+                    .postType(post.getPostType())
+                    .likesCount((long) post.getLikes().size())
+                    .build();
+        }
+
     }
 
     public static PostResponseDto.GetPostListResultDto toGetPostListResultDto(List<Post> posts) {

--- a/src/main/java/com/dto/way/post/converter/PostConverter.java
+++ b/src/main/java/com/dto/way/post/converter/PostConverter.java
@@ -18,6 +18,7 @@ public class PostConverter {
                     .imageUrl(post.getDaily().getImageUrl())
                     .postType(post.getPostType())
                     .likesCount((long) post.getLikes().size())
+                    .expiredOrCreatedDate(post.getDaily().getExpiredAt())
                     .build();
         }else {
             return PostResponseDto.GetPostResultDto.builder()
@@ -27,6 +28,7 @@ public class PostConverter {
                     .imageUrl(post.getHistory().getThumbnailImageUrl())
                     .postType(post.getPostType())
                     .likesCount((long) post.getLikes().size())
+                    .expiredOrCreatedDate(post.getHistory().getCreatedAt())
                     .build();
         }
 

--- a/src/main/java/com/dto/way/post/domain/Post.java
+++ b/src/main/java/com/dto/way/post/domain/Post.java
@@ -23,6 +23,10 @@ public class Post  {
     @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Daily daily;
 
+    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private History history;
+
+
     //TODO: 프론트에서 좌표로 받을 건지, 주소로 받아서 벡에서 좌표로 변환할건지 논의 필요
     // -> 좌표로 받는게 훨씬 편할 거 같긴한데 뭐가 맞는거지
     private Double latitude;

--- a/src/main/java/com/dto/way/post/repository/PostRepository.java
+++ b/src/main/java/com/dto/way/post/repository/PostRepository.java
@@ -25,11 +25,4 @@ public interface PostRepository extends JpaRepository<Post, Long> {
                                @Param("y1") Double left_y,
                                @Param("x2") Double right_x,
                                @Param("y2") Double right_y);
-
-    @Query(value = "SELECT new com.dto.way.post.web.dto.postDto.PostResponseDto.GetPinResultDto(p.id,  p.latitude, p.longitude,p.postType) FROM Post p " +
-            "WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true",nativeQuery = true)
-    List<PostResponseDto.GetPinResultDto> findPinByRange(@Param("x1") Double left_x,
-                                                         @Param("y1") Double left_y,
-                                                         @Param("x2") Double right_x,
-                                                         @Param("y2") Double right_y);
 }

--- a/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
@@ -21,6 +21,7 @@ public class PostResponseDto {
         private String imageUrl;
         private PostType postType;
         private Long likesCount;
+        private LocalDateTime expiredOrCreatedDate;
         //TODO: 생성일자 추가하기
     }
 

--- a/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
@@ -17,13 +17,10 @@ public class PostResponseDto {
     public static class GetPostResultDto {
         private Long postId;
         private Long memberId;
-        private Double latitude;
-        private Double longitude;
         private String title;
-        private String body;
         private String imageUrl;
-        private LocalDateTime expiredAt;
         private PostType postType;
+        private Long likesCount;
         //TODO: 생성일자 추가하기
     }
 


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
<img width="1011" alt="image" src="https://github.com/KEA4th-DTO/WAY_BE_PostService/assets/101577272/445f7bbb-927a-4b7b-88ba-bf5797465926">
문제였던 데일리 의존적인 부분을 수정함으로써 게시글 타입 상관 없이 전제 조회 가능. 
response에 body, 위도, 경도 제거.
데일리의 경우 만료 시간, 히스토리의 경우 생성 시간 응답.

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
