### PR TITLE
DTO-270 Fix: 기존 api에 auth를 추가한다

### DIFF
--- a/src/main/java/com/dto/way/post/converter/DailyConverter.java
+++ b/src/main/java/com/dto/way/post/converter/DailyConverter.java
@@ -54,7 +54,7 @@ public class DailyConverter {
     public static DailyResponseDto.GetDailyResultDto toGetDailyResponseDto(Daily daily) {
         return DailyResponseDto.GetDailyResultDto.builder()
                 .postId(daily.getPostId())
-                .writerId(daily.getPost().getMemberId())
+                .writerEmail(daily.getPost().getMemberEmail())
                 .title(daily.getTitle())
                 .body(daily.getBody())
                 .imageUrl(daily.getImageUrl())

--- a/src/main/java/com/dto/way/post/converter/PostConverter.java
+++ b/src/main/java/com/dto/way/post/converter/PostConverter.java
@@ -13,7 +13,7 @@ public class PostConverter {
         if(post.getPostType()== PostType.DAILY){
             return PostResponseDto.GetPostResultDto.builder()
                     .postId(post.getId())
-                    .memberId(post.getMemberId())
+                    .memberEmail(post.getMemberEmail())
                     .title(post.getDaily().getTitle())
                     .imageUrl(post.getDaily().getImageUrl())
                     .postType(post.getPostType())
@@ -23,7 +23,7 @@ public class PostConverter {
         }else {
             return PostResponseDto.GetPostResultDto.builder()
                     .postId(post.getId())
-                    .memberId(post.getMemberId())
+                    .memberEmail(post.getMemberEmail())
                     .title(post.getHistory().getTitle())
                     .imageUrl(post.getHistory().getThumbnailImageUrl())
                     .postType(post.getPostType())

--- a/src/main/java/com/dto/way/post/domain/Post.java
+++ b/src/main/java/com/dto/way/post/domain/Post.java
@@ -35,10 +35,6 @@ public class Post  {
     @Column(columnDefinition = "geometry(Point, 4326)") // PostgreSQL
     private Point point;
 
-    //연관관계 매핑은 추후에 생각
-    //private Member member;
-    private Long memberId;
-
     private String memberEmail;
 
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/com/dto/way/post/domain/Post.java
+++ b/src/main/java/com/dto/way/post/domain/Post.java
@@ -39,16 +39,15 @@ public class Post  {
     //private Member member;
     private Long memberId;
 
+    private String memberEmail;
+
     @Enumerated(value = EnumType.STRING)
     private PostType postType;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Like> likes = new ArrayList<>();
 
-    public void setMemberId(Long memberId) {
-        this.memberId = memberId;
-    }
-    public void setPoint(Point point) {
-        this.point = point;
+    public void setMemberEmail(String memberEmail) {
+        this.memberEmail = memberEmail;
     }
 }

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyCommandService.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyCommandService.java
@@ -4,14 +4,15 @@ import com.dto.way.post.domain.Daily;
 import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
 import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
 import org.locationtech.jts.io.ParseException;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
 public interface DailyCommandService {
-    Daily createDaily(MultipartFile image, DailyRequestDto.CreateDailyDto requestDto) throws ParseException;   //  회원 서비스 구현 완료시 수정사항 있음
+    Daily createDaily(Authentication auth, MultipartFile image, DailyRequestDto.CreateDailyDto requestDto) throws ParseException;   //  회원 서비스 구현 완료시 수정사항 있음
 
-    Daily updateDaily(Long dailyId, DailyRequestDto.UpdateDailyDto requestDto);
+    Daily updateDaily(Authentication auth, Long dailyId, DailyRequestDto.UpdateDailyDto requestDto);
 
-    DailyResponseDto.DeleteDailyResultDto deleteDaily(Long dailyId) throws IOException;
+    DailyResponseDto.DeleteDailyResultDto deleteDaily(Authentication auth, Long dailyId) throws IOException;
 }

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyQueryServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyQueryServiceImpl.java
@@ -32,7 +32,7 @@ public class DailyQueryServiceImpl implements DailyQueryService {
     @Override
     public DailyResponseDto.GetDailyListResultDto getDailyListByRange(Double longitude1, Double latitude1, Double longitude2, Double latitude2) {
 
-        String sql = "SELECT p.member_id, p.post_id, d.title, d.image_url, d.body, d.created_at, d.expired_at FROM post p JOIN daily d ON d.post_id = p.post_id WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true";
+        String sql = "SELECT p.member_email, p.post_id, d.title, d.image_url, d.body, d.created_at, d.expired_at FROM post p JOIN daily d ON d.post_id = p.post_id WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true";
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter("x1", longitude1);
         query.setParameter("y1", latitude1);
@@ -43,7 +43,7 @@ public class DailyQueryServiceImpl implements DailyQueryService {
         List<DailyResponseDto.GetDailyResultDto> dtoList = rawResultList.stream()
                 .map(result -> {
                     DailyResponseDto.GetDailyResultDto dto = new DailyResponseDto.GetDailyResultDto();
-                    dto.setWriterId((Long) result[0]);
+                    dto.setWriterEmail((String) result[0]);
                     dto.setPostId((Long) result[1]);
                     dto.setTitle((String) result[2]);
                     dto.setImageUrl((String) result[3]);

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryCommandService.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryCommandService.java
@@ -4,14 +4,15 @@ import com.dto.way.post.domain.History;
 import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
 import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
 import org.locationtech.jts.io.ParseException;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
 public interface HistoryCommandService {
 
-    History createHistory(MultipartFile thumbnailImage, MultipartFile bodyHtml, HistoryRequestDto.CreateHistoryDto createHistoryDto) throws ParseException;
+    History createHistory(Authentication auth, MultipartFile thumbnailImage, MultipartFile bodyHtml, HistoryRequestDto.CreateHistoryDto createHistoryDto) throws ParseException;
 
-    HistoryResponseDto.DeleteHistoryResultDto deleteHistory(Long postId) throws IOException;
+    HistoryResponseDto.DeleteHistoryResultDto deleteHistory(Authentication auth, Long postId) throws IOException;
 
 }

--- a/src/main/java/com/dto/way/post/web/controller/DailyRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/DailyRestController.java
@@ -10,6 +10,7 @@ import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
 import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.io.ParseException;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -32,9 +33,10 @@ public class DailyRestController {
      * @throws ParseException
      */
     @PostMapping
-    public ApiResponse<DailyResponseDto.CreateDailyResultDto> createDaily(@RequestPart(value = "image", required = true) MultipartFile image,
+    public ApiResponse<DailyResponseDto.CreateDailyResultDto> createDaily(Authentication auth,
+                                                                          @RequestPart(value = "image", required = true) MultipartFile image,
                                                                           @RequestPart(value = "createDailyDto") DailyRequestDto.CreateDailyDto request) throws ParseException {
-        Daily daily = dailyCommandService.createDaily(image, request);
+        Daily daily = dailyCommandService.createDaily(auth, image, request);
         return ApiResponse.of(SuccessStatus.DAILY_CREATED, DailyConverter.toCreateDailyResultDto(daily));
     }
 
@@ -46,9 +48,11 @@ public class DailyRestController {
      * @return
      */
     @PatchMapping("/{postId}")
-    public ApiResponse<DailyResponseDto.UpdateDailyResultDto> updateDaily(@PathVariable(name = "postId") Long postId, @RequestBody DailyRequestDto.UpdateDailyDto request) {
+    public ApiResponse<DailyResponseDto.UpdateDailyResultDto> updateDaily(Authentication auth,
+                                                                          @PathVariable(name = "postId") Long postId,
+                                                                          @RequestBody DailyRequestDto.UpdateDailyDto request) {
 
-        Daily daily = dailyCommandService.updateDaily(postId, request);
+        Daily daily = dailyCommandService.updateDaily(auth, postId, request);
         return ApiResponse.of(SuccessStatus.DAILY_UPDATED, DailyConverter.toUpdateDailyResponseDto(daily));
     }
 
@@ -60,8 +64,9 @@ public class DailyRestController {
      * @throws IOException
      */
     @DeleteMapping("/{postId}")
-    public ApiResponse<DailyResponseDto.DeleteDailyResultDto> deleteDaily(@PathVariable(name = "postId") Long postId) throws IOException {
-        return ApiResponse.of(SuccessStatus.DAILY_DELETED, dailyCommandService.deleteDaily(postId));
+    public ApiResponse<DailyResponseDto.DeleteDailyResultDto> deleteDaily(Authentication auth,
+                                                                          @PathVariable(name = "postId") Long postId) throws IOException {
+        return ApiResponse.of(SuccessStatus.DAILY_DELETED, dailyCommandService.deleteDaily(auth, postId));
     }
 
     /**

--- a/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
@@ -9,6 +9,7 @@ import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
 import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.io.ParseException;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,15 +23,17 @@ public class HistoryRestController {
     private final HistoryCommandService historyCommandService;
 
     @PostMapping
-    public ApiResponse<HistoryResponseDto.CreateHistoryResultDto> createHistory(@RequestPart(value = "image",required = true) MultipartFile thumbnailImage,
+    public ApiResponse<HistoryResponseDto.CreateHistoryResultDto> createHistory(Authentication auth,
+                                                                                @RequestPart(value = "image",required = true) MultipartFile thumbnailImage,
                                                                                 @RequestPart(value = "html",required = true) MultipartFile bodyHtml,
                                                                                 @RequestPart(value = "createHistoryDto", required = true)HistoryRequestDto.CreateHistoryDto request) throws ParseException {
-        History history = historyCommandService.createHistory(thumbnailImage, bodyHtml, request);
+        History history = historyCommandService.createHistory(auth, thumbnailImage, bodyHtml, request);
         return ApiResponse.of(SuccessStatus.HISTORY_CREATED, HistoryConverter.toCreateHistoryResponseDto(history));
     }
 
     @DeleteMapping("/{postId}")
-    public ApiResponse<HistoryResponseDto.DeleteHistoryResultDto> deleteHistory(@PathVariable(name = "postId") Long postId) throws IOException {
-        return ApiResponse.of(SuccessStatus.HISTORY_DELETED, historyCommandService.deleteHistory(postId));
+    public ApiResponse<HistoryResponseDto.DeleteHistoryResultDto> deleteHistory(Authentication auth,
+                                                                                @PathVariable(name = "postId") Long postId) throws IOException {
+        return ApiResponse.of(SuccessStatus.HISTORY_DELETED, historyCommandService.deleteHistory(auth, postId));
     }
 }

--- a/src/main/java/com/dto/way/post/web/dto/dailyDto/DailyResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/dailyDto/DailyResponseDto.java
@@ -43,12 +43,8 @@ public class DailyResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetDailyResultDto {
-        /**
-         * 작성자에 대한 정보
-         * 프로필이미지, 닉네임
-         */
         private Long postId;
-        private Long writerId;
+        private String writerEmail;
         private String title;
         private String body;
         private String imageUrl;

--- a/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
@@ -16,7 +16,7 @@ public class PostResponseDto {
     @AllArgsConstructor
     public static class GetPostResultDto {
         private Long postId;
-        private Long memberId;
+        private String memberEmail;
         private String title;
         private String imageUrl;
         private PostType postType;


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
기존 api에 auth를 추가한다

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->
#26 

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
API를 요청하는 사용자 정보를 확인하고 작성자와 요청자가 같은 경우, 다른 경우에 따라 다르게 처리해야하는 부분이 있어 controller에 Authentication을 추가하였다. 
ex) 작성자만 게시글을 수정/삭제할 수 있다. -> API 요청 사용자와 글 작성자와 같은지 확인하는 과정 필요

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
