### PR TITLE
DTO-271 Feat: history 게시글 상세조회 api 구현

### DIFF
--- a/src/main/java/com/dto/way/post/converter/HistoryConverter.java
+++ b/src/main/java/com/dto/way/post/converter/HistoryConverter.java
@@ -42,4 +42,14 @@ public class HistoryConverter {
                 .build();
     }
 
+    public static HistoryResponseDto.GetHistoryResultDto toGetHistoryResultDto(History history) {
+        return HistoryResponseDto.GetHistoryResultDto.builder()
+                .postId(history.getPostId())
+                .memberEmail(history.getPost().getMemberEmail())
+                .title(history.getTitle())
+                .bodyHtmlUrl(history.getBodyHtmlUrl())
+                .commentsCount(999L)
+                .createdAt(history.getCreatedAt()).build();
+    }
+
 }

--- a/src/main/java/com/dto/way/post/global/JwtTokenProvider.java
+++ b/src/main/java/com/dto/way/post/global/JwtTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtTokenProvider {
     private final Key key;
 
     // application.yml에서 secret 값 가져와서 key에 저장
-    public JwtTokenProvider(@Value("e9caf9e059da3ae65f50ef782115ec956422ef5ce30838059523cbe77e93ecbe") String secretKey) {
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }

--- a/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
@@ -38,8 +38,8 @@ public enum SuccessStatus implements BaseCode {
     //  히스토리 관련 응답
     HISTORY_CREATED(HttpStatus.OK, "HISTORY2001", "History 게시글이 생성되었습니다."),
     HISTORY_DELETED(HttpStatus.OK, "HISTORY2002", "History 게시글이 삭제되었습니다."),
-
-
+    //  히스토리 수정 응답 HISTORY2003
+    HISTORY_FOUND(HttpStatus.OK,"HISTORY2004","History 게시글이 조회되었습니다."),
 
     ;
 

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryQueryService.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryQueryService.java
@@ -1,0 +1,7 @@
+package com.dto.way.post.service.historyService;
+
+import com.dto.way.post.domain.History;
+
+public interface HistoryQueryService {
+    History getHistory(Long postId);
+}

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryQueryServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryQueryServiceImpl.java
@@ -1,0 +1,20 @@
+package com.dto.way.post.service.historyService;
+
+import com.dto.way.post.domain.History;
+import com.dto.way.post.repository.HistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryQueryServiceImpl implements HistoryQueryService{
+
+    private final HistoryRepository historyRepository;
+    
+    @Override
+    public History getHistory(Long postId) {
+
+        History history = historyRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("해당 히스토리가 존재하지 않습니다."));
+        return history;
+    }
+}

--- a/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
@@ -5,6 +5,7 @@ import com.dto.way.post.domain.History;
 import com.dto.way.post.global.response.ApiResponse;
 import com.dto.way.post.global.response.code.status.SuccessStatus;
 import com.dto.way.post.service.historyService.HistoryCommandService;
+import com.dto.way.post.service.historyService.HistoryQueryService;
 import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
 import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -21,12 +22,13 @@ import java.io.IOException;
 @RequestMapping("/history-service")
 public class HistoryRestController {
     private final HistoryCommandService historyCommandService;
+    private final HistoryQueryService historyQueryService;
 
     @PostMapping
     public ApiResponse<HistoryResponseDto.CreateHistoryResultDto> createHistory(Authentication auth,
-                                                                                @RequestPart(value = "image",required = true) MultipartFile thumbnailImage,
-                                                                                @RequestPart(value = "html",required = true) MultipartFile bodyHtml,
-                                                                                @RequestPart(value = "createHistoryDto", required = true)HistoryRequestDto.CreateHistoryDto request) throws ParseException {
+                                                                                @RequestPart(value = "image", required = true) MultipartFile thumbnailImage,
+                                                                                @RequestPart(value = "html", required = true) MultipartFile bodyHtml,
+                                                                                @RequestPart(value = "createHistoryDto", required = true) HistoryRequestDto.CreateHistoryDto request) throws ParseException {
         History history = historyCommandService.createHistory(auth, thumbnailImage, bodyHtml, request);
         return ApiResponse.of(SuccessStatus.HISTORY_CREATED, HistoryConverter.toCreateHistoryResponseDto(history));
     }
@@ -35,5 +37,13 @@ public class HistoryRestController {
     public ApiResponse<HistoryResponseDto.DeleteHistoryResultDto> deleteHistory(Authentication auth,
                                                                                 @PathVariable(name = "postId") Long postId) throws IOException {
         return ApiResponse.of(SuccessStatus.HISTORY_DELETED, historyCommandService.deleteHistory(auth, postId));
+    }
+
+    @GetMapping("/{postId}")
+    public ApiResponse<HistoryResponseDto.GetHistoryResultDto> getHistory(@PathVariable(name = "postId") Long postId) {
+
+        History history = historyQueryService.getHistory(postId);
+        HistoryResponseDto.GetHistoryResultDto getHistoryResultDto = HistoryConverter.toGetHistoryResultDto(history);
+        return ApiResponse.of(SuccessStatus.HISTORY_FOUND, getHistoryResultDto);
     }
 }

--- a/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
@@ -29,4 +29,17 @@ public class HistoryResponseDto {
         private String title;
         private LocalDateTime deletedAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetHistoryResultDto {
+        private Long postId;
+        private String memberEmail;
+        private String title;
+        private String bodyHtmlUrl;
+        private Long commentsCount;
+        private LocalDateTime createdAt;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,9 @@ spring:
         show_sql: true #show sql
       database-platform: org.hibernate.spatial.dialect.postgis.PostgisDialect
 
+jwt:
+  secret: ${JWT_SECRET}
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
history 게시글 상세조회 api 구현

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->
close #28 

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
![image](https://github.com/KEA4th-DTO/WAY_BE_PostService/assets/101577272/1f1c811a-2aa2-4435-9005-f3177ff20487)
API: http://localhost:8080/history-service/{postId}

TODO: 댓글 기능 구현 시 dto에 댓글 수 추가

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
