### PR TITLE
DTO-274 Feat: history 게시글 목록 범위 조회 구현

### DIFF
--- a/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
@@ -43,6 +43,8 @@ public enum SuccessStatus implements BaseCode {
     HISTORY_DELETED(HttpStatus.OK, "HISTORY2002", "History 게시글이 삭제되었습니다."),
     //  히스토리 수정 응답 HISTORY2003
     HISTORY_FOUND(HttpStatus.OK,"HISTORY2004","History 게시글이 조회되었습니다."),
+    HISTORY_LIST_FOUND_BY_RANGE(HttpStatus.OK,"HISTORY2005","반경 내 History 게시글 목록이 조회되었습니다."),
+
 
 
     //  댓글 관련 응답

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyQueryService.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyQueryService.java
@@ -3,12 +3,13 @@ package com.dto.way.post.service.dailyService;
 import com.dto.way.post.domain.Daily;
 import com.dto.way.post.domain.Post;
 import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
+import org.springframework.security.core.Authentication;
 
 import java.util.List;
 
 public interface DailyQueryService {
     Daily getDaily(Long postId);
 
-    DailyResponseDto.GetDailyListResultDto getDailyListByRange(Double longitude1, Double latitude1, Double longitude2, Double latitude2);
+    DailyResponseDto.GetDailyListResultDto getDailyListByRange(Authentication auth,Double longitude1, Double latitude1, Double longitude2, Double latitude2);
 
 }

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryQueryService.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryQueryService.java
@@ -1,7 +1,11 @@
 package com.dto.way.post.service.historyService;
 
 import com.dto.way.post.domain.History;
+import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
+import org.springframework.security.core.Authentication;
 
 public interface HistoryQueryService {
     History getHistory(Long postId);
+
+    HistoryResponseDto.GetHistoryListResultDto getHistoryListByRange(Authentication auth, Double longitude1, Double latitude1, Double longitude2, Double latitude2);
 }

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryQueryServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryQueryServiceImpl.java
@@ -2,19 +2,60 @@ package com.dto.way.post.service.historyService;
 
 import com.dto.way.post.domain.History;
 import com.dto.way.post.repository.HistoryRepository;
+import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
+import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class HistoryQueryServiceImpl implements HistoryQueryService{
 
     private final HistoryRepository historyRepository;
+    private final EntityManager entityManager;
+
     
     @Override
     public History getHistory(Long postId) {
 
         History history = historyRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("해당 히스토리가 존재하지 않습니다."));
         return history;
+    }
+
+    @Override
+    public HistoryResponseDto.GetHistoryListResultDto getHistoryListByRange(Authentication auth, Double longitude1, Double latitude1, Double longitude2, Double latitude2) {
+        String sql = "SELECT p.member_email, p.post_id, h.title, h.body_html_url, h.created_at FROM post p JOIN history h ON h.post_id = p.post_id WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true";
+        Query query = entityManager.createNativeQuery(sql);
+        query.setParameter("x1", longitude1);
+        query.setParameter("y1", latitude1);
+        query.setParameter("x2", longitude2);
+        query.setParameter("y2", latitude2);
+
+        String loginMemberEmail = auth.getName();
+
+        List<Object[]> rawResultList = query.getResultList();
+        List<HistoryResponseDto.GetHistoryResultDto> dtoList = rawResultList.stream()
+                .map(result -> {
+                    HistoryResponseDto.GetHistoryResultDto dto = new HistoryResponseDto.GetHistoryResultDto();
+                    Boolean isOwned = ((String) result[0]).equals(loginMemberEmail);
+                    dto.setIsOwned(isOwned);
+                    dto.setMemberEmail((String) result[0]);
+                    dto.setPostId((Long) result[1]);
+                    dto.setTitle((String) result[2]);
+                    dto.setBodyHtmlUrl((String) result[3]);
+                    dto.setCreatedAt(((Timestamp) result[4]).toLocalDateTime());
+                    return dto;
+                })
+                .collect(Collectors.toList());
+
+        HistoryResponseDto.GetHistoryListResultDto result = new HistoryResponseDto.GetHistoryListResultDto(dtoList);
+        return result;
     }
 }

--- a/src/main/java/com/dto/way/post/web/controller/DailyRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/DailyRestController.java
@@ -86,12 +86,13 @@ public class DailyRestController {
 
     // 반경 내 데일리 목록 조회 API
     @GetMapping("/posts")
-    public ApiResponse<DailyResponseDto.GetDailyListResultDto> getDailyList(@RequestParam Double latitude1,
+    public ApiResponse<DailyResponseDto.GetDailyListResultDto> getDailyList(Authentication auth,
+                                                                            @RequestParam Double latitude1,
                                                                             @RequestParam Double longitude1,
                                                                             @RequestParam Double latitude2,
                                                                             @RequestParam Double longitude2) {
 
-        DailyResponseDto.GetDailyListResultDto dailyList = dailyQueryService.getDailyListByRange(latitude1, longitude1, latitude2, longitude2);
-        return ApiResponse.of(SuccessStatus.PINS_FOUND_BY_RANGE, dailyList);
+        DailyResponseDto.GetDailyListResultDto dailyList = dailyQueryService.getDailyListByRange(auth, latitude1, longitude1, latitude2, longitude2);
+        return ApiResponse.of(SuccessStatus.DAILY_LIST_FOUND_BY_RANGE, dailyList);
     }
 }

--- a/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
@@ -49,4 +49,15 @@ public class HistoryRestController {
         HistoryResponseDto.GetHistoryResultDto getHistoryResultDto = HistoryConverter.toGetHistoryResultDto(history, commentCommandService.countComment(postId));
         return ApiResponse.of(SuccessStatus.HISTORY_FOUND, getHistoryResultDto);
     }
+
+    @GetMapping("/history-list")
+    public ApiResponse<HistoryResponseDto.GetHistoryListResultDto> getHistoryList(Authentication auth,
+                                                                                  @RequestParam Double latitude1,
+                                                                                  @RequestParam Double longitude1,
+                                                                                  @RequestParam Double latitude2,
+                                                                                  @RequestParam Double longitude2) {
+
+        HistoryResponseDto.GetHistoryListResultDto historyDtoList = historyQueryService.getHistoryListByRange(auth, latitude1, longitude1, latitude2, longitude2);
+        return ApiResponse.of(SuccessStatus.HISTORY_LIST_FOUND_BY_RANGE, historyDtoList);
+    }
 }

--- a/src/main/java/com/dto/way/post/web/dto/dailyDto/DailyResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/dailyDto/DailyResponseDto.java
@@ -48,6 +48,7 @@ public class DailyResponseDto {
         private String title;
         private String body;
         private String imageUrl;
+        private Boolean isOwned;
         private LocalDateTime expiredAt;
         private LocalDateTime createdAt;
     }

--- a/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
@@ -1,11 +1,9 @@
 package com.dto.way.post.web.dto.historyDto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class HistoryResponseDto {
 
@@ -31,6 +29,7 @@ public class HistoryResponseDto {
     }
 
     @Getter
+    @Setter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
@@ -40,6 +39,16 @@ public class HistoryResponseDto {
         private String title;
         private String bodyHtmlUrl;
         private Long commentsCount;
+        private Boolean isOwned;
         private LocalDateTime createdAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetHistoryListResultDto {
+        private List<GetHistoryResultDto> historyResultDtoList;
+    }
+
 }


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
history 게시글 목록 범위 조회 구현

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
history 게시글 목록 범위 조회 구현
좌하단, 우상단 좌표를 통해 해당 범위 내의 히스토리 게시글 목록을 조회하는 API를 구현하였음


## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
