### PR TITLE
DTO-359 Feat: 사용자의 게시글 수를 조회하는 api 구현

### DIFF
--- a/src/main/java/com/dto/way/post/Application.java
+++ b/src/main/java/com/dto/way/post/Application.java
@@ -1,9 +1,12 @@
 package com.dto.way.post;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.TimeZone;
 
 
 @EnableJpaAuditing // JPA Auditing 활성화
@@ -16,4 +19,10 @@ public class Application {
 		System.out.println(org.hibernate.Version.getVersionString());
 	}
 
+	@PostConstruct
+	public void init() {
+		// timezone 설정
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+		System.out.println("Current TimeZone: " + TimeZone.getDefault().getID());
+	}
 }

--- a/src/main/java/com/dto/way/post/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/dto/way/post/aws/s3/AmazonS3Manager.java
@@ -2,6 +2,7 @@ package com.dto.way.post.aws.s3;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.dto.way.post.aws.config.AmazonConfig;
@@ -35,14 +36,24 @@ public class AmazonS3Manager {
 
 
     public void deleteFile(String directoryPath, String fileUrl) throws IOException {
-        int indexOfReviews = fileUrl.indexOf(directoryPath + "/");
+        // 예상된 S3 버킷 URL 패턴
+        String s3UrlPattern = "https://way-bucket-s3.s3.ap-northeast-2.amazonaws.com/";
 
-        String fileKey = fileUrl.substring(indexOfReviews);
+        // URL이 예상된 패턴으로 시작하는지 확인
+        if (!fileUrl.startsWith(s3UrlPattern)) {
+            throw new IllegalArgumentException("Invalid S3 URL: " + fileUrl);
+        }
+
+        // 파일 키 추출
+        String fileKey = fileUrl.substring(s3UrlPattern.length());
+
+        log.info("s3 객체 키: " + fileKey);
         try {
             amazonS3.deleteObject(amazonConfig.getBucket(), fileKey);
+
         } catch (SdkClientException e) {
+            log.error("Error deleting file from S3", e);
             throw new IOException("Error deleting file from S3", e);
         }
     }
-
 }

--- a/src/main/java/com/dto/way/post/repository/PostRepository.java
+++ b/src/main/java/com/dto/way/post/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package com.dto.way.post.repository;
 
 import com.dto.way.post.domain.Post;
+import com.dto.way.post.domain.enums.PostType;
 import com.dto.way.post.web.dto.postDto.PostResponseDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -38,4 +39,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
                                        @Param("x2") Double right_x,
                                        @Param("y2") Double right_y);
 
+    @Query("SELECT COUNT(p) FROM Post p WHERE p.postType = :postType AND p.memberId = :memberId")
+    Long countByPostTypeAndMemberId(@Param("postType") PostType postType, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/dto/way/post/service/postService/PostQueryService.java
+++ b/src/main/java/com/dto/way/post/service/postService/PostQueryService.java
@@ -19,4 +19,5 @@ public interface PostQueryService {
 
     PostResponseDto.GetPinListResultDto getPersonalPinListByRange(String memberNickname);
 
+    PostResponseDto.GetPostCountDto getPostCount(Long memberId);
 }

--- a/src/main/java/com/dto/way/post/service/postService/PostQueryServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/postService/PostQueryServiceImpl.java
@@ -4,6 +4,8 @@ import com.dto.way.post.converter.PostConverter;
 import com.dto.way.post.domain.Post;
 import com.dto.way.post.domain.enums.PostType;
 import com.dto.way.post.global.utils.JwtUtils;
+import com.dto.way.post.repository.DailyRepository;
+import com.dto.way.post.repository.HistoryRepository;
 import com.dto.way.post.repository.LikeRepository;
 import com.dto.way.post.repository.PostRepository;
 import com.dto.way.post.web.dto.memberDto.MemberResponseDto;
@@ -30,6 +32,8 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
+    private final HistoryRepository historyRepository;
+    private final DailyRepository dailyRepository;
     private final EntityManager entityManager;
     private final JwtUtils jwtUtils;
     private final MemberClient memberClient;
@@ -122,5 +126,18 @@ public class PostQueryServiceImpl implements PostQueryService {
         PostResponseDto.GetPinListResultDto result = new PostResponseDto.GetPinListResultDto(dtoList);
         return result;
     }
+
+    @Override
+    public PostResponseDto.GetPostCountDto getPostCount(Long memberId) {
+
+        Long historyCount = postRepository.countByPostTypeAndMemberId(PostType.HISTORY, memberId);
+        Long dailyCount = postRepository.countByPostTypeAndMemberId(PostType.DAILY, memberId);
+
+        return PostResponseDto.GetPostCountDto.builder()
+                .historyCount(historyCount)
+                .dailyCount(dailyCount)
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/dto/way/post/web/controller/PostRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/PostRestController.java
@@ -112,4 +112,10 @@ public class PostRestController {
         return ApiResponse.of(status, dto);
     }
 
+    @Operation(summary = "특정 사용자의 게시글 수를 반환하는 openFeign을 위한 API 입니다.", description = "RequestParam으로 memberId를 전송해주세요.")
+    @GetMapping("/count/")
+    public PostResponseDto.GetPostCountDto getPostCount(@RequestParam Long memberId) {
+        return postQueryService.getPostCount(memberId);
+    }
+
 }

--- a/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
@@ -60,4 +60,13 @@ public class PostResponseDto {
         private List<GetPinResultDto> pinResultDtoList;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPostCountDto {
+        private Long dailyCount;
+        private Long historyCount;
+    }
+
 }


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
사용자의 게시글 수를 조회하는 api 구현

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
member-service에서 사용자의 게시글 수 데이터가 필요함. 따라서 openfeign으로 데이터를 넘겨주기 위해 memberId로 게시글 수를 조회하는 API를 구현하였음.

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
