### PR TITLE
DTO-374 Fix: 히스토리 본문 데이터를 html이 아닌 문자열로 저장

### DIFF
--- a/src/main/java/com/dto/way/post/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/dto/way/post/aws/s3/AmazonS3Manager.java
@@ -35,7 +35,7 @@ public class AmazonS3Manager {
     }
 
 
-    public void deleteFile(String directoryPath, String fileUrl) throws IOException {
+    public void deleteFile(String fileUrl) throws IOException {
         // 예상된 S3 버킷 URL 패턴
         String s3UrlPattern = "https://way-bucket-s3.s3.ap-northeast-2.amazonaws.com/";
 

--- a/src/main/java/com/dto/way/post/converter/HistoryConverter.java
+++ b/src/main/java/com/dto/way/post/converter/HistoryConverter.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 public class HistoryConverter {
 
-    public static History toHistory(Point point, String thumbnailImageUrl, String bodyHtmlUrl, HistoryRequestDto.CreateHistoryDto createHistoryDto) {
+    public static History toHistory(Point point, String thumbnailImageUrl, HistoryRequestDto.CreateHistoryDto createHistoryDto) {
         Post post = Post.builder()
                 .latitude(createHistoryDto.getLatitude())
                 .longitude(createHistoryDto.getLongitude())
@@ -22,7 +22,7 @@ public class HistoryConverter {
         return History.builder()
                 .title(createHistoryDto.getTitle())
                 .bodyPreview(createHistoryDto.getBodyPreview())
-                .bodyHtmlUrl(bodyHtmlUrl)
+                .body(createHistoryDto.getBody())
                 .thumbnailImageUrl(thumbnailImageUrl)
                 .post(post)
                 .build();

--- a/src/main/java/com/dto/way/post/domain/History.java
+++ b/src/main/java/com/dto/way/post/domain/History.java
@@ -26,17 +26,13 @@ public class History extends BaseEntity {
     private List<Comment> comments = new ArrayList<>();
 
     private String title;
-    private String bodyHtmlUrl;
+    private String body;
     private String thumbnailImageUrl;
     private String bodyPreview;
 
 
     public void updateTitle(String title) {
         this.title = title;
-    }
-
-    public void updateBodyHtmlUrl(String bodyHtmlUrl) {
-        this.bodyHtmlUrl = bodyHtmlUrl;
     }
 
     public void updateThumbnailImageUrl(String thumbnailImageUrl) {

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyCommandServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyCommandServiceImpl.java
@@ -95,7 +95,7 @@ public class DailyCommandServiceImpl implements DailyCommandService {
 
         if (loginMemberId.equals(daily.getPost().getMemberId())) {
             //  사용자와 작성자가 같으면 삭제 가능
-            s3Manager.deleteFile(amazonConfig.getDailyImagePath(), daily.getImageUrl());
+            s3Manager.deleteFile(daily.getImageUrl());
             dailyRepository.delete(daily);
         } else {
             //  사용자와 작성자가 다르면 예외처리

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryCommandService.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryCommandService.java
@@ -12,11 +12,11 @@ import java.io.IOException;
 
 public interface HistoryCommandService {
 
-    History createHistory(HttpServletRequest httpServletRequest, MultipartFile thumbnailImage, MultipartFile bodyHtml, HistoryRequestDto.CreateHistoryDto createHistoryDto) throws ParseException;
+    History createHistory(HttpServletRequest httpServletRequest, MultipartFile thumbnailImage, HistoryRequestDto.CreateHistoryDto createHistoryDto) throws ParseException;
 
     HistoryResponseDto.DeleteHistoryResultDto deleteHistory(HttpServletRequest httpServletRequest, Long postId) throws IOException;
 
-    History updateHistory(HttpServletRequest httpServletRequest, Long postId,MultipartFile thumbnailImage, MultipartFile bodyHtml, HistoryRequestDto.UpdateHistoryDto updateHistoryDto) throws IOException;
+    History updateHistory(HttpServletRequest httpServletRequest, Long postId, MultipartFile bodyHtml, HistoryRequestDto.UpdateHistoryDto updateHistoryDto) throws IOException;
 
     String historyImageUrl(MultipartFile historyImage);
 

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryQueryServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryQueryServiceImpl.java
@@ -13,7 +13,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
@@ -50,8 +49,8 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
         return HistoryResponseDto.GetHistoryResultDto.builder()
                 .postId(history.getPostId())
                 .title(history.getTitle())
-                .bodyHtmlUrl(history.getBodyHtmlUrl())
                 .bodyPreview(history.getBodyPreview())
+                .body(history.getBody())
                 .isOwned(isOwned)
                 .isLiked(isLiked)
                 .likesCount(countLike)
@@ -61,7 +60,7 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
 
     @Override
     public HistoryResponseDto.GetHistoryListResultDto getHistoryListByRange(HttpServletRequest httpServletRequest, Double longitude1, Double latitude1, Double longitude2, Double latitude2) {
-        String sql = "SELECT p.member_id, p.post_id, h.title, h.body_html_url, h.created_at,h.body_preview FROM post p JOIN history h ON h.post_id = p.post_id WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true";
+        String sql = "SELECT p.member_id, p.post_id, h.title, h.body, h.created_at,h.body_preview FROM post p JOIN history h ON h.post_id = p.post_id WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true";
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter("x1", longitude1);
         query.setParameter("y1", latitude1);
@@ -78,7 +77,7 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
                     dto.setIsOwned(isOwned);
                     dto.setPostId((Long) result[1]);
                     dto.setTitle((String) result[2]);
-                    dto.setBodyHtmlUrl((String) result[3]);
+                    dto.setBody((String) result[3]);
                     dto.setCreatedAt(((Timestamp) result[4]).toLocalDateTime());
                     dto.setBodyPreview((String) result[5]);
 

--- a/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
@@ -30,13 +30,12 @@ public class HistoryRestController {
     private final HistoryQueryService historyQueryService;
 
 
-    @Operation(summary = "History 게시글 생성 API", description = "form-data 형식으로 썸네일 이미지(image), 본문 html(bodyHtml), createHistoryDto을 전송해주세요.")
+    @Operation(summary = "History 게시글 생성 API", description = "form-data 형식으로 썸네일 이미지(image), createHistoryDto을 전송해주세요.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<HistoryResponseDto.CreateHistoryResultDto> createHistory(HttpServletRequest httpServletRequest,
-                                                                                @RequestPart(value = "image", required = true) MultipartFile thumbnailImage,
-                                                                                @RequestPart(value = "html", required = true) MultipartFile bodyHtml,
+                                                                                @RequestPart(value = "thumbnailImage", required = true) MultipartFile thumbnailImage,
                                                                                 @Valid @RequestPart(value = "createHistoryDto", required = true) HistoryRequestDto.CreateHistoryDto request) throws ParseException {
-        History history = historyCommandService.createHistory(httpServletRequest, thumbnailImage, bodyHtml, request);
+        History history = historyCommandService.createHistory(httpServletRequest, thumbnailImage, request);
         return ApiResponse.of(SuccessStatus.HISTORY_CREATED, HistoryConverter.toCreateHistoryResponseDto(history));
     }
 
@@ -47,14 +46,13 @@ public class HistoryRestController {
         return ApiResponse.of(SuccessStatus.HISTORY_DELETED, historyCommandService.deleteHistory(httpServletRequest, postId));
     }
 
-    @Operation(summary = "History 게시글 수정 API", description = "form-data 형식으로 수정할 썸네일 이미지(image), 본문 html(bodyHtml), updateHistoryDto을 전송해주세요.")
+    @Operation(summary = "History 게시글 수정 API", description = "form-data 형식으로 수정할 썸네일 이미지(image), updateHistoryDto을 전송해주세요.")
     @PatchMapping(value = "/{postId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<HistoryResponseDto.UpdateHistoryResultDto> updateHistory(HttpServletRequest httpServletRequest,
                                                                                 @PathVariable(name = "postId") Long postId,
-                                                                                @RequestPart(value = "image", required = true) MultipartFile thumbnailImage,
-                                                                                @RequestPart(value = "html", required = true) MultipartFile bodyHtml,
+                                                                                @RequestPart(value = "thumbnailImage", required = true) MultipartFile thumbnailImage,
                                                                                 @Valid @RequestPart(value = "updateHistoryDto", required = true) HistoryRequestDto.UpdateHistoryDto request) throws IOException {
-        History history = historyCommandService.updateHistory(httpServletRequest, postId, thumbnailImage, bodyHtml, request);
+        History history = historyCommandService.updateHistory(httpServletRequest, postId, thumbnailImage, request);
         return ApiResponse.of(SuccessStatus.HISTORY_UPDATE, HistoryConverter.toUpdateHistoryResponseDto(history));
     }
 
@@ -79,12 +77,12 @@ public class HistoryRestController {
         return ApiResponse.of(SuccessStatus.HISTORY_LIST_FOUND_BY_RANGE, historyDtoList);
     }
 
-    @Operation(summary = "History 이미지를 url로 변환하는 API",description = "Requestbody의 form-data 형식으로 변환할 이미지 파일을 전송해주세요. ")
+    @Operation(summary = "History 이미지를 url로 변환하는 API", description = "Requestbody의 form-data 형식으로 변환할 이미지 파일을 전송해주세요. ")
     @PostMapping(value = "/upload-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> getImageUrlFromS3(@RequestParam(name = "historyImage") MultipartFile historyImage) {
 
         String historyImageUrl = historyCommandService.historyImageUrl(historyImage);
-        return ApiResponse.of(SuccessStatus.HISTORY_IMAGE_URL,historyImageUrl);
+        return ApiResponse.of(SuccessStatus.HISTORY_IMAGE_URL, historyImageUrl);
     }
 
 }

--- a/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryRequestDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryRequestDto.java
@@ -14,6 +14,8 @@ public class HistoryRequestDto {
         @NotBlank(message = "제목을 입력해주세요.")
         private String title;
 
+        private String body;
+
         @NotNull(message = "경도 좌표를 입력해주세요.")
         private Double latitude;
 
@@ -35,6 +37,8 @@ public class HistoryRequestDto {
         @NotBlank(message = "제목을 입력해주세요.")
         private String title;
 
+        private String body;
+
         @NotNull(message = "경도 좌표를 입력해주세요.")
         private Double latitude;
 
@@ -46,6 +50,7 @@ public class HistoryRequestDto {
 
         @NotBlank(message = "미리보기를 입력해주세요.")
         private String bodyPreview;
+
 
     }
 

--- a/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
@@ -48,7 +48,7 @@ public class HistoryResponseDto {
         private String writerNickname;
         private String writerProfileImageUrl;
         private String title;
-        private String bodyHtmlUrl;
+        private String body;
         private String bodyPreview;
         private Boolean isLiked;
         private Long likesCount;


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
히스토리 본문 데이터를 html이 아닌 문자열로 저장

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->


## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
Frontend에서 ToastUI를 사용하여 history 게시글 내용을 불러오기 위해서 body를 html에서 string 형식으로 변경.

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
