### PR TITLE
DTO-373 Feat: 만료시간에 따라 데일리를 조회 가능 여부를 체크

### DIFF
--- a/src/main/java/com/dto/way/post/converter/DailyConverter.java
+++ b/src/main/java/com/dto/way/post/converter/DailyConverter.java
@@ -2,6 +2,7 @@ package com.dto.way.post.converter;
 
 import com.dto.way.post.domain.Daily;
 import com.dto.way.post.domain.Post;
+import com.dto.way.post.domain.enums.PostStatus;
 import com.dto.way.post.domain.enums.PostType;
 import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
 import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
@@ -14,6 +15,7 @@ public class DailyConverter {
         Post postRequest = Post.builder()
                 .longitude(request.getLongitude())
                 .latitude(request.getLatitude())
+                .postStatus(PostStatus.NOT_EXPIRED)
                 .postType(PostType.DAILY)
                 .point(point)
                 .address(request.getAddress())

--- a/src/main/java/com/dto/way/post/converter/DailyConverter.java
+++ b/src/main/java/com/dto/way/post/converter/DailyConverter.java
@@ -2,7 +2,7 @@ package com.dto.way.post.converter;
 
 import com.dto.way.post.domain.Daily;
 import com.dto.way.post.domain.Post;
-import com.dto.way.post.domain.enums.PostStatus;
+import com.dto.way.post.domain.enums.Expiration;
 import com.dto.way.post.domain.enums.PostType;
 import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
 import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
@@ -15,7 +15,7 @@ public class DailyConverter {
         Post postRequest = Post.builder()
                 .longitude(request.getLongitude())
                 .latitude(request.getLatitude())
-                .postStatus(PostStatus.NOT_EXPIRED)
+                .postStatus(Expiration.NOT_EXPIRED)
                 .postType(PostType.DAILY)
                 .point(point)
                 .address(request.getAddress())

--- a/src/main/java/com/dto/way/post/converter/HistoryConverter.java
+++ b/src/main/java/com/dto/way/post/converter/HistoryConverter.java
@@ -2,7 +2,7 @@ package com.dto.way.post.converter;
 
 import com.dto.way.post.domain.History;
 import com.dto.way.post.domain.Post;
-import com.dto.way.post.domain.enums.PostStatus;
+import com.dto.way.post.domain.enums.Expiration;
 import com.dto.way.post.domain.enums.PostType;
 import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
 import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
@@ -16,7 +16,7 @@ public class HistoryConverter {
         Post post = Post.builder()
                 .latitude(createHistoryDto.getLatitude())
                 .longitude(createHistoryDto.getLongitude())
-                .postStatus(PostStatus.NO_EXPIRATION)
+                .postStatus(Expiration.NO_EXPIRATION)
                 .postType(PostType.HISTORY)
                 .address(createHistoryDto.getAddress())
                 .point(point).build();

--- a/src/main/java/com/dto/way/post/converter/HistoryConverter.java
+++ b/src/main/java/com/dto/way/post/converter/HistoryConverter.java
@@ -2,6 +2,7 @@ package com.dto.way.post.converter;
 
 import com.dto.way.post.domain.History;
 import com.dto.way.post.domain.Post;
+import com.dto.way.post.domain.enums.PostStatus;
 import com.dto.way.post.domain.enums.PostType;
 import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
 import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
@@ -15,6 +16,7 @@ public class HistoryConverter {
         Post post = Post.builder()
                 .latitude(createHistoryDto.getLatitude())
                 .longitude(createHistoryDto.getLongitude())
+                .postStatus(PostStatus.NO_EXPIRATION)
                 .postType(PostType.HISTORY)
                 .address(createHistoryDto.getAddress())
                 .point(point).build();

--- a/src/main/java/com/dto/way/post/converter/PostConverter.java
+++ b/src/main/java/com/dto/way/post/converter/PostConverter.java
@@ -36,6 +36,7 @@ public class PostConverter {
                     .inOwned(isOwned)
                     .createdAt(post.getDaily().getCreatedAt())
                     .expiredAt(post.getDaily().getExpiredAt())
+                    .postStatus(post.getPostStatus())
                     .build();
         } else {
             return PostResponseDto.GetPostResultDto.builder()
@@ -51,6 +52,7 @@ public class PostConverter {
                     .commentsCount((long) post.getHistory().getComments().size())
                     .inOwned(isOwned)
                     .createdAt(post.getHistory().getCreatedAt())
+                    .postStatus(post.getPostStatus())
                     .build();
         }
 

--- a/src/main/java/com/dto/way/post/domain/Post.java
+++ b/src/main/java/com/dto/way/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.dto.way.post.domain;
 
+import com.dto.way.post.domain.enums.PostStatus;
 import com.dto.way.post.domain.enums.PostType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -38,11 +39,17 @@ public class Post  {
     @Enumerated(value = EnumType.STRING)
     private PostType postType;
 
+    @Enumerated(value = EnumType.STRING)
+    private PostStatus postStatus;
+
+    public void updatePostStatus(PostStatus postStatus) {
+        this.postStatus = postStatus;
+    }
+
     private String address;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Like> likes = new ArrayList<>();
-
 
     public void setMemberId(Long memberId) {
         this.memberId = memberId;

--- a/src/main/java/com/dto/way/post/domain/Post.java
+++ b/src/main/java/com/dto/way/post/domain/Post.java
@@ -1,9 +1,8 @@
 package com.dto.way.post.domain;
 
-import com.dto.way.post.domain.enums.PostStatus;
+import com.dto.way.post.domain.enums.Expiration;
 import com.dto.way.post.domain.enums.PostType;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import org.locationtech.jts.geom.Point;
 
@@ -15,7 +14,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post  {
+public class Post {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,11 +39,7 @@ public class Post  {
     private PostType postType;
 
     @Enumerated(value = EnumType.STRING)
-    private PostStatus postStatus;
-
-    public void updatePostStatus(PostStatus postStatus) {
-        this.postStatus = postStatus;
-    }
+    private Expiration postStatus;
 
     private String address;
 
@@ -54,7 +49,6 @@ public class Post  {
     public void setMemberId(Long memberId) {
         this.memberId = memberId;
     }
-
 
     public void updateLatitude(Double latitude) {
         this.latitude = latitude;
@@ -68,4 +62,7 @@ public class Post  {
         this.address = address;
     }
 
+    public void updateExpiration(Expiration postStatus) {
+        this.postStatus = postStatus;
+    }
 }

--- a/src/main/java/com/dto/way/post/domain/enums/Expiration.java
+++ b/src/main/java/com/dto/way/post/domain/enums/Expiration.java
@@ -1,6 +1,6 @@
 package com.dto.way.post.domain.enums;
 
-public enum PostStatus {
+public enum Expiration {
     EXPIRED,
     NOT_EXPIRED,
     NO_EXPIRATION

--- a/src/main/java/com/dto/way/post/domain/enums/PostStatus.java
+++ b/src/main/java/com/dto/way/post/domain/enums/PostStatus.java
@@ -1,0 +1,8 @@
+package com.dto.way.post.domain.enums;
+
+public enum PostStatus {
+    EXPIRED,
+    NOT_EXPIRED,
+    NO_EXPIRATION
+
+}

--- a/src/main/java/com/dto/way/post/global/config/SchedulingConfig.java
+++ b/src/main/java/com/dto/way/post/global/config/SchedulingConfig.java
@@ -1,0 +1,8 @@
+package com.dto.way.post.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulingConfig {}

--- a/src/main/java/com/dto/way/post/repository/DailyRepository.java
+++ b/src/main/java/com/dto/way/post/repository/DailyRepository.java
@@ -2,9 +2,15 @@ package com.dto.way.post.repository;
 
 import com.dto.way.post.domain.Daily;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface DailyRepository extends JpaRepository<Daily, Long> {
 
     Optional<Daily> findById(Long postId);
+
+    List<Daily> findByExpiredAtBefore(LocalDateTime now);
+
 }

--- a/src/main/java/com/dto/way/post/repository/PostRepository.java
+++ b/src/main/java/com/dto/way/post/repository/PostRepository.java
@@ -24,7 +24,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 
     @Query(value = "SELECT * FROM Post p " +
-            "WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true", nativeQuery = true)
+            "WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true " +
+            "AND p.post_status <> 'EXPIRED'", nativeQuery = true)
     List<Post> findPostByRange(@Param("x1") Double left_x,
                                @Param("y1") Double left_y,
                                @Param("x2") Double right_x,

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyCommandService.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyCommandService.java
@@ -16,4 +16,7 @@ public interface DailyCommandService {
     Daily updateDaily(HttpServletRequest httpServletRequest, Long dailyId, DailyRequestDto.UpdateDailyDto requestDto);
 
     DailyResponseDto.DeleteDailyResultDto deleteDaily(HttpServletRequest httpServletRequest, Long dailyId) throws IOException;
+
+    void changePostStatus();
+
 }

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyCommandServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyCommandServiceImpl.java
@@ -5,14 +5,12 @@ import com.dto.way.post.converter.DailyConverter;
 import com.dto.way.post.domain.Daily;
 import com.dto.way.post.domain.Post;
 import com.dto.way.post.aws.config.AmazonConfig;
-import com.dto.way.post.domain.enums.PostStatus;
+import com.dto.way.post.domain.enums.Expiration;
 import com.dto.way.post.global.utils.JwtUtils;
 import com.dto.way.post.repository.DailyRepository;
-import com.dto.way.post.repository.UuidRepository;
 import com.dto.way.post.utils.UuidCreator;
 import com.dto.way.post.web.dto.dailyDto.DailyRequestDto;
 import com.dto.way.post.web.dto.dailyDto.DailyResponseDto;
-import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
@@ -20,8 +18,6 @@ import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,7 +26,6 @@ import java.io.IOException;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -118,7 +113,7 @@ public class DailyCommandServiceImpl implements DailyCommandService {
         List<Daily> dailyList = dailyRepository.findByExpiredAtBefore(LocalDateTime.now());
 
         dailyList.forEach(daily -> {
-            daily.getPost().updatePostStatus(PostStatus.EXPIRED);
+            daily.getPost().updateExpiration(Expiration.EXPIRED);
         });
     }
 }

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyCommandServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.dto.way.post.converter.DailyConverter;
 import com.dto.way.post.domain.Daily;
 import com.dto.way.post.domain.Post;
 import com.dto.way.post.aws.config.AmazonConfig;
+import com.dto.way.post.domain.enums.PostStatus;
 import com.dto.way.post.global.utils.JwtUtils;
 import com.dto.way.post.repository.DailyRepository;
 import com.dto.way.post.repository.UuidRepository;
@@ -17,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
@@ -26,6 +29,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.DateTimeException;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -103,5 +108,17 @@ public class DailyCommandServiceImpl implements DailyCommandService {
         }
 
         return deleteDailyResultDto;
+    }
+
+    @Override
+    @Transactional
+    @Async
+    @Scheduled(cron = "0 */10 * * * *") //  10분 단위로 Daily의 만료 날짜를 확인해서 상태를 변경한다.
+    public void changePostStatus() {
+        List<Daily> dailyList = dailyRepository.findByExpiredAtBefore(LocalDateTime.now());
+
+        dailyList.forEach(daily -> {
+            daily.getPost().updatePostStatus(PostStatus.EXPIRED);
+        });
     }
 }

--- a/src/main/java/com/dto/way/post/service/dailyService/DailyQueryServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/dailyService/DailyQueryServiceImpl.java
@@ -57,7 +57,11 @@ public class DailyQueryServiceImpl implements DailyQueryService {
     public DailyResponseDto.GetDailyListResultDto getDailyListByRange(HttpServletRequest httpServletRequest, Double longitude1, Double latitude1, Double longitude2, Double latitude2) {
 
 
-        String sql = "SELECT p.member_id, p.post_id, d.title, d.image_url, d.body, d.created_at, d.expired_at FROM post p JOIN daily d ON d.post_id = p.post_id WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true";
+        String sql = "SELECT p.member_id, p.post_id, d.title, d.image_url, d.body, d.created_at, d.expired_at " +
+                "FROM post p " +
+                "JOIN daily d ON d.post_id = p.post_id " +
+                "WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true " +
+                "AND p.post_status <> 'EXPIRED'";
 
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter("x1", longitude1);

--- a/src/main/java/com/dto/way/post/service/postService/PostQueryServiceImpl.java
+++ b/src/main/java/com/dto/way/post/service/postService/PostQueryServiceImpl.java
@@ -32,8 +32,6 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     private final PostRepository postRepository;
     private final LikeRepository likeRepository;
-    private final HistoryRepository historyRepository;
-    private final DailyRepository dailyRepository;
     private final EntityManager entityManager;
     private final JwtUtils jwtUtils;
     private final MemberClient memberClient;
@@ -90,7 +88,11 @@ public class PostQueryServiceImpl implements PostQueryService {
     @Override
     public PostResponseDto.GetPinListResultDto getPinListByRange(Double longitude1, Double latitude1, Double longitude2, Double latitude2) {
 
-        String sql = "SELECT p.post_id,  p.latitude, p.longitude, p.post_type FROM post p WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true";
+        String sql = "SELECT p.post_id, p.latitude, p.longitude, p.post_type " +
+                "FROM post p " +
+                "WHERE ST_Contains(ST_MakeEnvelope(:x1, :y1, :x2, :y2, 4326), p.point) = true " +
+                "AND p.post_status <> 'EXPIRED'";
+
         Query query = entityManager.createNativeQuery(sql);
         query.setParameter("x1", longitude1);
         query.setParameter("y1", latitude1);

--- a/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/postDto/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.dto.way.post.web.dto.postDto;
 
+import com.dto.way.post.domain.enums.Expiration;
 import com.dto.way.post.domain.enums.PostType;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -27,6 +28,7 @@ public class PostResponseDto {
         private Long commentsCount;
         private LocalDateTime createdAt;
         private LocalDateTime expiredAt;
+        private Expiration postStatus;
         private Boolean inOwned;
     }
 


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
만료시간에 따라 데일리를 조회 가능 여부를 체크

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
post Entity에 expiration 필드를 추가하였다. (enum type: EXPIRED, NOT_EXPIRED, NO_EXPIRATION)
10분 간격으로 애플리케이션이 daily의 만료시간을 확인하고 만료시간이 지났으면 상태를 EXPIRED로 업데이트한다. 
로컬맵에서는 만료된 데일리 게시글은 확인할 수 없으며, 사용자의 프로필에 들어가서는 확인할 수 있도록 API를 수정하였다. 

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
