### PR TITLE
DTO-382 Feat: history 게시글 검색 API 구현(제목, 내용)

### DIFF
--- a/src/main/java/com/dto/way/post/converter/HistoryConverter.java
+++ b/src/main/java/com/dto/way/post/converter/HistoryConverter.java
@@ -7,8 +7,11 @@ import com.dto.way.post.domain.enums.PostType;
 import com.dto.way.post.web.dto.historyDto.HistoryRequestDto;
 import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
 import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class HistoryConverter {
 
@@ -54,5 +57,25 @@ public class HistoryConverter {
                 .build();
     }
 
+    public static HistoryResponseDto.HistorySearchResultDto toHistorySearchResultDto(History history) {
+        return HistoryResponseDto.HistorySearchResultDto.builder()
+                .postId(history.getPostId())
+                .title(history.getTitle())
+                .bodyPreview(history.getBodyPreview())
+                .createdAt(history.getCreatedAt())
+                .build();
+    }
 
+    public static HistoryResponseDto.HistorySearchResultListDto toHistorySearchResultListDto(Page<History> historyPage) {
+        List<HistoryResponseDto.HistorySearchResultDto> historySearchResultDtoList = historyPage.stream()
+                .map(HistoryConverter::toHistorySearchResultDto).collect(Collectors.toList());
+
+        return HistoryResponseDto.HistorySearchResultListDto.builder()
+                .historySearchResultDtoList(historySearchResultDtoList)
+                .isFirst(historyPage.isFirst())
+                .isLast(historyPage.isLast())
+                .totalPage(historyPage.getTotalPages())
+                .listSize(historyPage.getSize())
+                .build();
+    }
 }

--- a/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
@@ -45,8 +45,8 @@ public enum SuccessStatus implements BaseCode {
     HISTORY_FOUND(HttpStatus.OK,"HISTORY2004","History 게시글이 조회되었습니다."),
     HISTORY_LIST_FOUND_BY_RANGE(HttpStatus.OK,"HISTORY2005","반경 내 History 게시글 목록이 조회되었습니다."),
     HISTORY_IMAGE_URL(HttpStatus.OK,"HISTORY2006","이미지를 URL로 변환하였습니다."),
-
-
+    HISTORY_TITLE_SEARCH(HttpStatus.OK, "HISTORY2007", "제목 키워드 검색을 성공했습니다. "),
+    HISTORY_BODY_SEARCH(HttpStatus.OK, "HISTORY2008", "내용 키워드 검색을 성공했습니다. "),
 
 
     //  댓글 관련 응답
@@ -66,8 +66,6 @@ public enum SuccessStatus implements BaseCode {
 
     //  신고 관련 응답
     REPORT_CREATED(HttpStatus.OK, "REPORT2001", "신고 목록에 추가되었습니다."),
-
-
     ;
 
 

--- a/src/main/java/com/dto/way/post/repository/HistoryRepository.java
+++ b/src/main/java/com/dto/way/post/repository/HistoryRepository.java
@@ -1,6 +1,8 @@
 package com.dto.way.post.repository;
 
 import com.dto.way.post.domain.History;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,4 +12,9 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     Optional<History> findById(Long Id);
 
     Long countByPostMemberId(Long memberId);
+
+    Page<History> findByTitleContaining(PageRequest pageRequest, String title);
+
+    Page<History> findByBodyContaining(PageRequest pageRequest, String body);
+
 }

--- a/src/main/java/com/dto/way/post/service/historyService/HistoryQueryService.java
+++ b/src/main/java/com/dto/way/post/service/historyService/HistoryQueryService.java
@@ -1,10 +1,20 @@
 package com.dto.way.post.service.historyService;
 
+import com.dto.way.post.domain.History;
 import com.dto.way.post.web.dto.historyDto.HistoryResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
 
 public interface HistoryQueryService {
     HistoryResponseDto.GetHistoryResultDto getHistoryResult(HttpServletRequest httpServletRequest, Long postId);
 
     HistoryResponseDto.GetHistoryListResultDto getHistoryListByRange(HttpServletRequest httpServletRequest, Double longitude1, Double latitude1, Double longitude2, Double latitude2);
+
+    Page<History> findHistoryByTitle(Integer page, String title);
+
+    Page<History> findHistoryByBody(Integer page, String body);
+
 }

--- a/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/HistoryRestController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.locationtech.jts.io.ParseException;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -77,6 +78,22 @@ public class HistoryRestController {
         return ApiResponse.of(SuccessStatus.HISTORY_LIST_FOUND_BY_RANGE, historyDtoList);
     }
 
+    @Operation(summary = "History 게시글 제목으로 검색 API", description = "RequestParam 으로 검색할 키워드와 page 번호를 전송해주세요.")
+    @GetMapping("/search/title")
+    public ApiResponse<HistoryResponseDto.HistorySearchResultListDto> searchHistoryByTitle(@RequestParam(name = "keyword") String keyword,
+                                                                                           @RequestParam(name = "page") Integer page) {
+        Page<History> historyPage = historyQueryService.findHistoryByTitle(page - 1, keyword);
+        return ApiResponse.of(SuccessStatus.HISTORY_TITLE_SEARCH, HistoryConverter.toHistorySearchResultListDto(historyPage));
+    }
+
+    @Operation(summary = "History 게시글 내용으로 검색 API", description = "RequestParam 으로 검색할 키워드와 page 번호를 전송해주세요.")
+    @GetMapping("/search/body")
+    public ApiResponse<HistoryResponseDto.HistorySearchResultListDto> searchHistoryByBody(@RequestParam(name = "keyword") String keyword,
+                                                                                          @RequestParam(name = "page") Integer page) {
+        Page<History> historyPage = historyQueryService.findHistoryByBody(page - 1, keyword);
+        return ApiResponse.of(SuccessStatus.HISTORY_BODY_SEARCH, HistoryConverter.toHistorySearchResultListDto(historyPage));
+    }
+
     @Operation(summary = "History 이미지를 url로 변환하는 API", description = "Requestbody의 form-data 형식으로 변환할 이미지 파일을 전송해주세요. ")
     @PostMapping(value = "/upload-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<String> getImageUrlFromS3(@RequestParam(name = "historyImage") MultipartFile historyImage) {
@@ -84,5 +101,6 @@ public class HistoryRestController {
         String historyImageUrl = historyCommandService.historyImageUrl(historyImage);
         return ApiResponse.of(SuccessStatus.HISTORY_IMAGE_URL, historyImageUrl);
     }
+
 
 }

--- a/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
+++ b/src/main/java/com/dto/way/post/web/dto/historyDto/HistoryResponseDto.java
@@ -68,4 +68,27 @@ public class HistoryResponseDto {
         private List<GetHistoryResultDto> historyResultDtoList;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HistorySearchResultDto{
+        private Long postId;
+        private String title;
+        private String bodyPreview;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HistorySearchResultListDto {
+        List<HistorySearchResultDto> historySearchResultDtoList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
 }


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
history 게시글 검색 API 구현(제목, 내용)

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
history 게시글 검색 API를 구현하였음.
RequestPram으로 검색하고 싶은 키워드와 page를 넘겨주면 해당하는 게시글 목록이 페이징 처리되어 조회됨.

## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
