### PR TITLE
DTO-395 Feat: 마이맵 핀, 게시글 목록 조회 API를 새로 구현 (기존의 사용자 정보로 조회와 분리)

### DIFF
--- a/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
+++ b/src/main/java/com/dto/way/post/global/response/code/status/SuccessStatus.java
@@ -30,6 +30,7 @@ public enum SuccessStatus implements BaseCode {
     POSTS_FOUND_BY_RANGE_PERSONAL(HttpStatus.OK,"POST2006", "해당 유저의 게시글 목록을 조회하였습니다."),
     PINS_FOUND_BY_RANGE_PERSONAL(HttpStatus.OK,"POST2007", "해당 유저의 핀을 모두 조회하였습니다."),
 
+
     //  데일리 관련 응답
     DAILY_CREATED(HttpStatus.OK, "DAILY2001", "Daily 게시글이 생성되었습니다."),
     DAILY_UPDATED(HttpStatus.OK,"DAILY2002","Daily 게시글이 수정되었습니다."),

--- a/src/main/java/com/dto/way/post/service/postService/PostQueryService.java
+++ b/src/main/java/com/dto/way/post/service/postService/PostQueryService.java
@@ -13,11 +13,15 @@ public interface PostQueryService {
 
     List<PostResponseDto.GetPostResultDto> getPostListByRange(HttpServletRequest httpServletRequest, Double longitude1, Double latitude1, Double longitude2, Double latitude2);
 
-    List<PostResponseDto.GetPostResultDto> getPersonalPostListByRange(HttpServletRequest httpServletRequest,String memberNickname);
+    List<PostResponseDto.GetPostResultDto> getPersonalPostListByRange(HttpServletRequest httpServletRequest, String memberNickname);
+
+    List<PostResponseDto.GetPostResultDto> getMyPostListByRange(HttpServletRequest httpServletRequest);
 
     PostResponseDto.GetPinListResultDto getPinListByRange(Double longitude1, Double latitude1, Double longitude2, Double latitude2);
 
     PostResponseDto.GetPinListResultDto getPersonalPinListByRange(String memberNickname);
+
+    PostResponseDto.GetPinListResultDto getMyPinListByRange(HttpServletRequest httpServletRequest);
 
     PostResponseDto.GetPostCountDto getPostCount(Long memberId);
 }

--- a/src/main/java/com/dto/way/post/web/controller/PostRestController.java
+++ b/src/main/java/com/dto/way/post/web/controller/PostRestController.java
@@ -60,12 +60,21 @@ public class PostRestController {
         return ApiResponse.of(SuccessStatus.POSTS_FOUND_BY_RANGE, PostConverter.toGetPostListResultDto(getPostResultDtoList));
     }
 
-    @Operation(summary = "게시글(Daily, History) 목록을 사용자 정보로 조회 API", description = "마이맵 화면에서 게시글 목록을 조회하기 위한 API 입니다. PathVariable 으로 사용자 정보(닉네임)를 전송해주세요.")
+    @Operation(summary = "[다른 사용자의 마이맵용] 게시글(Daily, History) 목록을 사용자 정보로 조회 API", description = "다른 사용자의 마이맵 화면에서 게시글 목록을 조회하기 위한 API 입니다. PathVariable 으로 사용자 정보(닉네임)를 전송해주세요.")
     @GetMapping("/list/{memberNickname}")
     public ApiResponse<PostResponseDto.GetPostListResultDto> getPersonalPostsByRange(HttpServletRequest httpServletRequest,
                                                                                      @PathVariable(name = "memberNickname") String memberNickname) {
 
         List<PostResponseDto.GetPostResultDto> getPostResultDtoList = postQueryService.getPersonalPostListByRange(httpServletRequest, memberNickname);
+
+        return ApiResponse.of(SuccessStatus.POSTS_FOUND_BY_RANGE_PERSONAL, PostConverter.toGetPostListResultDto(getPostResultDtoList));
+    }
+
+    @Operation(summary = "[마이맵용] 게시글(Daily, History) 목록을 사용자 정보로 조회 API", description = "로그인 되어있는 사용자의 마이맵 화면에서 게시글 목록을 조회하기 위한 API 입니다.")
+    @GetMapping("/list/my-map")
+    public ApiResponse<PostResponseDto.GetPostListResultDto> getMyPostsByRange(HttpServletRequest httpServletRequest) {
+
+        List<PostResponseDto.GetPostResultDto> getPostResultDtoList = postQueryService.getMyPostListByRange(httpServletRequest);
 
         return ApiResponse.of(SuccessStatus.POSTS_FOUND_BY_RANGE_PERSONAL, PostConverter.toGetPostListResultDto(getPostResultDtoList));
     }
@@ -82,7 +91,7 @@ public class PostRestController {
     }
 
 
-    @Operation(summary = "핀 목록을 범위, 사용자 정보를 사용하여 조회 API", description = "마이맵의 지도에 핀을 띄우기 위한 API 입니다. PathVariable 으로 사용자 정보(닉네임)를 전송해주세요.")
+    @Operation(summary = "[다른 사용자의 마이맵용] 핀 목록을 범위, 사용자 정보를 사용하여 조회 API", description = "다른 사용자의 마이맵에 핀을 띄우기 위한 API 입니다. PathVariable 으로 사용자 정보(닉네임)를 전송해주세요.")
     @GetMapping("/pin/{memberNickname}")
     public ApiResponse<PostResponseDto.GetPinListResultDto> getPersonalPinsByRange(@PathVariable(name = "memberNickname") String memberNickname) {
 
@@ -90,10 +99,18 @@ public class PostRestController {
         return ApiResponse.of(SuccessStatus.PINS_FOUND_BY_RANGE_PERSONAL, pinList);
     }
 
+    @Operation(summary = "[마이맵용] 핀 목록을 범위, 사용자 정보를 사용하여 조회 API", description = "로그인된 사용자의 마이맵에 핀을 띄우기 위한 API 입니다.")
+    @GetMapping("/pin/my-map")
+    public ApiResponse<PostResponseDto.GetPinListResultDto> getMyPinsByRange(HttpServletRequest httpServletRequest) {
+        PostResponseDto.GetPinListResultDto pinList = postQueryService.getMyPinListByRange(httpServletRequest);
+        return ApiResponse.of(SuccessStatus.PINS_FOUND_BY_RANGE_PERSONAL, pinList);
+    }
+
     @Operation(summary = "게시글(Daily, History) 좋아요 기능 API", description = "게시글에 좋아요/좋아요 취소 기능을 하는 API 입니다. PathVariable 으로 좋아요 처리를 할 게시글의 postId 를 전송해주세요.")
     @PostMapping("/like/{postId}")
     public ApiResponse<LikeResponseDto.LikeResultDto> likePost(HttpServletRequest httpServletRequest,
                                                                @PathVariable(name = "postId") Long postId) {
+
         Boolean isLiked = likeCommandService.likePost(httpServletRequest, postId);
         LikeResponseDto.LikeResultDto dto = new LikeResponseDto.LikeResultDto(postId, likeQueryService.countLikes(postId));
 


### PR DESCRIPTION
## 📌 요약
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
마이맵 핀, 게시글 목록 조회 API를 새로 구현 (기존의 사용자 정보로 조회와 분리)

## #️⃣ Issue Number or Link
<!--- 이슈 number 혹은 Link 기재 -->

## 📋 상세 내용
<!-- 변경 사항에 대해서 기재 -->
사용자 닉네임으로 핀, 게시글 목록을 조회하던 기존의 마이맵 조회 로직은 다른 사용자의 마이맵을 조회할 때 사용하도록 두고, 
로그인된 사용자의 마이맵 조회는 토큰 내의 정보를 이용하여 조회하도록 분리하였음


## ❓기타 문의사항

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

>Notion에 있는 git convention 참고
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
